### PR TITLE
bump version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ var (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "snowlastic-cli",
-	Version: "3.0.0",
+	Version: "3.1.0",
 	Short:   "Manage, update, and administer an elasticsearch server",
 	Long: `Interact with an elasticsearch server, including indexing documents
 from a snowflake database. For example:


### PR DESCRIPTION
bugfix: allow multiple function calls in --by argument to import command (i.e. `TO_CHAR(YEAR("document date"))`)